### PR TITLE
Fix token allocation reserved response handling

### DIFF
--- a/tests/test_model_context.py
+++ b/tests/test_model_context.py
@@ -1,0 +1,11 @@
+import types
+
+from utils.model_context import ModelContext
+
+
+def test_reserved_for_response_zero_respected():
+    mc = ModelContext('dummy-model')
+    # Inject capabilities to avoid provider lookup
+    mc._capabilities = types.SimpleNamespace(max_tokens=1000)
+    allocation = mc.calculate_token_allocation(reserved_for_response=0)
+    assert allocation.response_tokens == 0

--- a/utils/model_context.py
+++ b/utils/model_context.py
@@ -90,7 +90,10 @@ class ModelContext:
 
         # Calculate allocations
         content_tokens = int(total_tokens * content_ratio)
-        response_tokens = reserved_for_response or int(total_tokens * response_ratio)
+        if reserved_for_response is not None:
+            response_tokens = reserved_for_response
+        else:
+            response_tokens = int(total_tokens * response_ratio)
 
         # Sub-allocations within content budget
         file_tokens = int(content_tokens * file_ratio)


### PR DESCRIPTION
## Summary
- handle reserved_for_response=0 in ModelContext.calculate_token_allocation
- add regression test for reserved response token allocation

## Testing
- `python -m pytest tests/ -q`


------
https://chatgpt.com/codex/tasks/task_e_688f6dd34e4083318f8604b345be5067