### PR TITLE
Add interactive menu to beginner CLI

### DIFF
--- a/CLI_README.md
+++ b/CLI_README.md
@@ -1,0 +1,43 @@
+# Zen MCP Beginner CLI
+
+This README explains how to use `zen_cli.py` to configure and manage the Zen MCP server with a single interface.
+
+## Setup
+1. Ensure Python 3.11+ is installed.
+2. Clone this repository and enter the directory.
+3. Create the `.env` file with your API keys:
+   ```bash
+   python zen_cli.py setup --gemini <GEMINI_KEY> --openai <OPENAI_KEY>
+   ```
+   Either key may be omitted.
+
+## Managing Services
+- Run an interactive menu for common tasks
+  ```bash
+  python zen_cli.py menu
+  ```
+- **Start containers**
+  ```bash
+  python zen_cli.py start
+  ```
+- **Check status**
+  ```bash
+  python zen_cli.py status
+  ```
+- **Stop containers**
+  ```bash
+  python zen_cli.py stop
+  ```
+
+The CLI checks for Docker and shows a friendly warning if it isn't installed or running.
+
+## Testing
+Run the Python unit tests to verify core behaviour:
+```bash
+python -m pytest tests/ -v
+```
+For full simulation against a running Docker stack:
+```bash
+python communication_simulator_test.py --tests basic_conversation
+```
+This requires Docker and at least one valid API key.

--- a/README.md
+++ b/README.md
@@ -108,7 +108,16 @@ The final implementation resulted in a 26% improvement in JSON parsing performan
 git clone https://github.com/BeehiveInnovations/zen-mcp-server.git
 cd zen-mcp-server
 
-# One-command setup (includes Redis for AI conversations)
+# Beginner-friendly CLI
+python zen_cli.py menu    # interactive menu for setup/start/stop/status
+
+# Or run individual commands
+python zen_cli.py setup   # prompts for API keys and creates .env
+python zen_cli.py start   # builds images and starts services
+python zen_cli.py status  # shows running containers
+python zen_cli.py stop    # stops services
+
+# Or run the setup script directly
 ./setup-docker.sh
 ```
 

--- a/tests/test_cli_ui.py
+++ b/tests/test_cli_ui.py
@@ -1,0 +1,83 @@
+import os
+from types import SimpleNamespace
+
+import zen_cli
+
+
+def test_create_env_file(tmp_path):
+    env_path = tmp_path / ".env"
+    zen_cli.create_env_file("g-key", "o-key", filename=str(env_path))
+    content = env_path.read_text()
+    assert "GEMINI_API_KEY=g-key" in content
+    assert "OPENAI_API_KEY=o-key" in content
+
+
+def test_setup_creates_env(monkeypatch, tmp_path):
+    monkeypatch.chdir(tmp_path)
+    args = SimpleNamespace(gemini="gkey", openai="okey")
+    zen_cli.setup(args)
+    content = (tmp_path / ".env").read_text()
+    assert "GEMINI_API_KEY=gkey" in content
+    assert "OPENAI_API_KEY=okey" in content
+
+
+def test_start_without_env(monkeypatch, capsys, tmp_path):
+    # Ensure no .env exists and subprocess.run isn't called
+    monkeypatch.chdir(tmp_path)
+    called = {}
+
+    def fake_run(cmd, check):
+        called["cmd"] = cmd
+
+    monkeypatch.setattr(zen_cli, "run_command", fake_run)
+    zen_cli.start(SimpleNamespace())
+    captured = capsys.readouterr()
+    assert "No .env file" in captured.out
+    assert "cmd" not in called
+
+
+def test_start_missing_docker(monkeypatch, capsys, tmp_path):
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / ".env").write_text("GEMINI_API_KEY=dummy\n")
+    def fake_ensure():
+        print("Docker missing")
+        return False
+
+    monkeypatch.setattr(zen_cli, "ensure_docker", fake_ensure)
+    called = {}
+
+    def fake_run(cmd, check=True):
+        called["cmd"] = cmd
+
+    monkeypatch.setattr(zen_cli, "run_command", fake_run)
+    zen_cli.start(SimpleNamespace())
+    captured = capsys.readouterr()
+    assert "Docker" in captured.out
+    assert "cmd" not in called
+
+
+def test_start_runs_setup(monkeypatch, tmp_path):
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / ".env").write_text("OPENAI_API_KEY=x\n")
+    monkeypatch.setattr(zen_cli, "ensure_docker", lambda: True)
+    called = {}
+
+    def fake_run(cmd, check=True):
+        called["cmd"] = cmd
+
+    monkeypatch.setattr(zen_cli, "run_command", fake_run)
+    zen_cli.start(SimpleNamespace())
+    assert called["cmd"] == ["bash", "setup-docker.sh"]
+
+
+def test_menu_calls_status(monkeypatch):
+    calls = {}
+
+    def fake_status(_):
+        calls["status"] = True
+
+    monkeypatch.setattr(zen_cli, "status", fake_status)
+    inputs = iter(["4", "5"])
+    monkeypatch.setattr("builtins.input", lambda _: next(inputs))
+    zen_cli.menu(SimpleNamespace())
+    assert calls.get("status")

--- a/zen_cli.py
+++ b/zen_cli.py
@@ -1,0 +1,130 @@
+import argparse
+import subprocess
+import shutil
+from pathlib import Path
+from typing import Optional
+
+
+def create_env_file(gemini_key: Optional[str], openai_key: Optional[str], filename: Path | str = Path(".env")) -> Path:
+    """Create an .env file with provided API keys."""
+    filename = Path(filename)
+    lines = []
+    if gemini_key:
+        lines.append(f"GEMINI_API_KEY={gemini_key}")
+    if openai_key:
+        lines.append(f"OPENAI_API_KEY={openai_key}")
+    content = "\n".join(lines) + ("\n" if lines else "")
+    filename.write_text(content, encoding="utf-8")
+    return filename
+
+
+def run_command(command: list[str]) -> None:
+    """Run a system command, forwarding output to the user."""
+    try:
+        subprocess.run(command, check=True)
+    except FileNotFoundError as exc:
+        print(f"Command not found: {command[0]}")
+        raise SystemExit(1) from exc
+    except subprocess.CalledProcessError as exc:
+        print(f"Command failed: {' '.join(command)}")
+        raise SystemExit(exc.returncode) from exc
+
+
+def ensure_docker() -> bool:
+    """Return True if Docker CLI is available and daemon responsive."""
+    if shutil.which("docker") is None:
+        print("Docker is not installed. Please install Docker Desktop.")
+        return False
+    try:
+        subprocess.run(["docker", "info"], stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL, check=True)
+    except subprocess.CalledProcessError:
+        print("Docker daemon is not running. Start Docker and try again.")
+        return False
+    return True
+
+
+def setup(args: argparse.Namespace) -> None:
+    """Interactively create the .env file for API keys."""
+    gemini = args.gemini or input("Enter Gemini API Key (or leave blank): ").strip() or None
+    openai = args.openai or input("Enter OpenAI API Key (or leave blank): ").strip() or None
+    create_env_file(gemini, openai)
+    print("Created .env file")
+
+
+def start(_: argparse.Namespace) -> None:
+    """Start the MCP server via docker."""
+    if not Path(".env").exists():
+        print("No .env file found. Run 'python zen_cli.py setup' first.")
+        return
+    if ensure_docker():
+        run_command(["bash", "setup-docker.sh"])
+
+
+def stop(_: argparse.Namespace) -> None:
+    """Stop the MCP server."""
+    if ensure_docker():
+        run_command(["docker", "compose", "down"])
+
+
+def status(_: argparse.Namespace) -> None:
+    """Show docker compose status."""
+    if ensure_docker():
+        run_command(["docker", "compose", "ps"])
+
+
+def menu(_: argparse.Namespace) -> None:
+    """Interactive menu for beginners."""
+    from types import SimpleNamespace
+
+    options: dict[str, tuple[str, callable]] = {
+        "1": ("Setup API keys", lambda: setup(SimpleNamespace(gemini=None, openai=None))),
+        "2": ("Start services", lambda: start(SimpleNamespace())),
+        "3": ("Stop services", lambda: stop(SimpleNamespace())),
+        "4": ("Show status", lambda: status(SimpleNamespace())),
+    }
+
+    while True:
+        print("\nZen MCP Menu")
+        for key, (desc, _) in sorted(options.items()):
+            print(f"{key}) {desc}")
+        print("5) Exit")
+        choice = input("Select an option: ").strip()
+        if choice in {"5", "q", "quit", "exit"}:
+            break
+        action = options.get(choice)
+        if action:
+            action[1]()
+        else:
+            print("Invalid option")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Helper CLI for Zen MCP server")
+    subparsers = parser.add_subparsers(dest="command")
+
+    setup_parser = subparsers.add_parser("setup", help="Create .env with API keys")
+    setup_parser.add_argument("--gemini", help="Gemini API Key")
+    setup_parser.add_argument("--openai", help="OpenAI API Key")
+    setup_parser.set_defaults(func=setup)
+
+    start_parser = subparsers.add_parser("start", help="Start Docker services")
+    start_parser.set_defaults(func=start)
+
+    stop_parser = subparsers.add_parser("stop", help="Stop Docker services")
+    stop_parser.set_defaults(func=stop)
+
+    status_parser = subparsers.add_parser("status", help="Show Docker status")
+    status_parser.set_defaults(func=status)
+
+    menu_parser = subparsers.add_parser("menu", help="Interactive text menu")
+    menu_parser.set_defaults(func=menu)
+
+    args = parser.parse_args()
+    if hasattr(args, "func"):
+        args.func(args)
+    else:
+        parser.print_help()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- introduce interactive `menu` command for guided setup and Docker management
- refactor CLI to use `pathlib` for `.env` handling
- document new menu workflow and extend tests for interactive usage

## Testing
- `python -m pytest tests/ -v`


------
https://chatgpt.com/codex/tasks/task_e_688f702661848331b6eeade47811069c