### PR TITLE
Expose available model mapping in ModelProviderRegistry

### DIFF
--- a/tests/test_providers.py
+++ b/tests/test_providers.py
@@ -65,6 +65,29 @@ class TestModelProviderRegistry:
         assert ProviderType.GOOGLE in providers
         assert ProviderType.OPENAI in providers
 
+    @patch.dict(
+        os.environ,
+        {
+            "GEMINI_API_KEY": "test-gemini",
+            "OPENAI_API_KEY": "test-openai",
+        },
+    )
+    def test_get_available_models(self):
+        """Test mapping of models to providers when API keys are configured"""
+        ModelProviderRegistry.register_provider(ProviderType.GOOGLE, GeminiModelProvider)
+        ModelProviderRegistry.register_provider(ProviderType.OPENAI, OpenAIModelProvider)
+
+        models = ModelProviderRegistry.get_available_models()
+
+        assert models["gemini-2.5-flash-preview-05-20"] == ProviderType.GOOGLE
+        assert models["gemini-2.5-pro-preview-06-05"] == ProviderType.GOOGLE
+        # Gemini also exposes shorthand aliases that should be included
+        assert models["flash"] == ProviderType.GOOGLE
+        assert models["pro"] == ProviderType.GOOGLE
+
+        assert models["o3"] == ProviderType.OPENAI
+        assert models["o3-mini"] == ProviderType.OPENAI
+
 
 class TestGeminiProvider:
     """Test Gemini model provider"""


### PR DESCRIPTION
## Summary
- implement ModelProviderRegistry.get_available_models so it returns models for providers with configured API keys
- include both canonical model identifiers and shorthand aliases for providers such as Gemini
- add a regression test covering the new registry behaviour

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68c9b3b5c7448331a3912752cc6d5019